### PR TITLE
refactor: don't include root directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,10 @@ find_package(Eigen3 3.1.0 REQUIRED)
 find_package(Pangolin REQUIRED)
 find_package(realsense2)
 
-add_subdirectory(src)
 add_subdirectory(Thirdparty/g2o)
 add_subdirectory(Thirdparty/DBoW2)
 add_subdirectory(Thirdparty/Sophus)
+
+add_subdirectory(src)
 add_subdirectory(doc)
 add_subdirectory(Examples)

--- a/include/Atlas.h
+++ b/include/Atlas.h
@@ -27,14 +27,14 @@
 #include <set>
 #include <vector>
 
+#include "CameraModels/GeometricCamera.h"
+#include "CameraModels/KannalaBrandt8.h"
+#include "CameraModels/Pinhole.h"
 #include "Frame.h"
-#include "GeometricCamera.h"
-#include "KannalaBrandt8.h"
 #include "KeyFrame.h"
 #include "Map.h"
 #include "MapPoint.h"
 #include "ORBVocabulary.h"
-#include "Pinhole.h"
 
 namespace ORB_SLAM3 {
 

--- a/include/CameraModels/GeometricCamera.h
+++ b/include/CameraModels/GeometricCamera.h
@@ -32,8 +32,9 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/features2d/features2d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <sophus/se3.hpp>
 #include <vector>
+
+#include "sophus/se3.hpp"
 
 namespace ORB_SLAM3 {
 class GeometricCamera {

--- a/include/Converter.h
+++ b/include/Converter.h
@@ -25,10 +25,10 @@
 #include <Eigen/Dense>
 #include <opencv2/core/core.hpp>
 
-#include "Thirdparty/Sophus/sophus/se3.hpp"
-#include "Thirdparty/Sophus/sophus/sim3.hpp"
-#include "Thirdparty/g2o/g2o/types/se3quat.h"
-#include "Thirdparty/g2o/g2o/types/sim3.h"
+#include "g2o/types/se3quat.h"
+#include "g2o/types/sim3.h"
+#include "sophus/se3.hpp"
+#include "sophus/sim3.hpp"
 
 namespace ORB_SLAM3 {
 

--- a/include/G2oTypes.h
+++ b/include/G2oTypes.h
@@ -30,11 +30,11 @@
 #include <opencv2/core/core.hpp>
 
 #include "ImuTypes.h"
-#include "Thirdparty/g2o/g2o/core/base_binary_edge.h"
-#include "Thirdparty/g2o/g2o/core/base_multi_edge.h"
-#include "Thirdparty/g2o/g2o/core/base_unary_edge.h"
-#include "Thirdparty/g2o/g2o/core/base_vertex.h"
-#include "Thirdparty/g2o/g2o/types/types_sba.h"
+#include "g2o/core/base_binary_edge.h"
+#include "g2o/core/base_multi_edge.h"
+#include "g2o/core/base_unary_edge.h"
+#include "g2o/core/base_vertex.h"
+#include "g2o/types/types_sba.h"
 
 namespace ORB_SLAM3 {
 

--- a/include/GeometricTools.h
+++ b/include/GeometricTools.h
@@ -23,8 +23,8 @@
 #define GEOMETRIC_TOOLS_H
 
 #include <Eigen/Core>
+#include <iostream>
 #include <opencv2/core/core.hpp>
-#include <sophus/se3.hpp>
 
 namespace ORB_SLAM3 {
 

--- a/include/ImuTypes.h
+++ b/include/ImuTypes.h
@@ -29,10 +29,10 @@
 #include <boost/serialization/vector.hpp>
 #include <mutex>
 #include <opencv2/core/core.hpp>
-#include <sophus/se3.hpp>
 #include <vector>
 
 #include "SerializationUtils.h"
+#include "sophus/se3.hpp"
 
 namespace ORB_SLAM3 {
 

--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -27,11 +27,11 @@
 #include <map>
 #include <set>
 
+#include "DBoW2/BowVector.h"
+#include "DBoW2/FeatureVector.h"
 #include "ImuTypes.h"
 #include "ORBVocabulary.h"
-#include "Thirdparty/DBoW2/DBoW2/BowVector.h"
-#include "Thirdparty/DBoW2/DBoW2/FeatureVector.h"
-#include "Thirdparty/Sophus/sophus/se3.hpp"
+#include "sophus/se3.hpp"
 
 namespace ORB_SLAM3 {
 

--- a/include/LoopClosing.h
+++ b/include/LoopClosing.h
@@ -29,7 +29,7 @@
 #include <utility>
 
 #include "ORBVocabulary.h"
-#include "Thirdparty/g2o/g2o/types/sim3.h"
+#include "g2o/types/sim3.h"
 
 namespace ORB_SLAM3 {
 

--- a/include/Map.h
+++ b/include/Map.h
@@ -30,7 +30,7 @@
 #include <set>
 
 #include "ORBVocabulary.h"
-#include "Thirdparty/Sophus/sophus/se3.hpp"
+#include "sophus/se3.hpp"
 
 namespace ORB_SLAM3 {
 

--- a/include/MapDrawer.h
+++ b/include/MapDrawer.h
@@ -26,7 +26,7 @@
 
 #include <mutex>
 
-#include "Thirdparty/Sophus/sophus/se3.hpp"
+#include "sophus/se3.hpp"
 
 namespace ORB_SLAM3 {
 

--- a/include/ORBVocabulary.h
+++ b/include/ORBVocabulary.h
@@ -22,8 +22,8 @@
 #ifndef ORBVOCABULARY_H
 #define ORBVOCABULARY_H
 
-#include "Thirdparty/DBoW2/DBoW2/FORB.h"
-#include "Thirdparty/DBoW2/DBoW2/TemplatedVocabulary.h"
+#include "DBoW2/FORB.h"
+#include "DBoW2/TemplatedVocabulary.h"
 
 namespace ORB_SLAM3 {
 

--- a/include/OptimizableTypes.h
+++ b/include/OptimizableTypes.h
@@ -22,13 +22,12 @@
 #ifndef ORB_SLAM3_OPTIMIZABLETYPES_H
 #define ORB_SLAM3_OPTIMIZABLETYPES_H
 
-#include <Thirdparty/g2o/g2o/types/sim3.h>
-#include <Thirdparty/g2o/g2o/types/types_six_dof_expmap.h>
-#include <include/CameraModels/GeometricCamera.h>
-
 #include <Eigen/Geometry>
 
-#include "Thirdparty/g2o/g2o/core/base_unary_edge.h"
+#include "CameraModels/GeometricCamera.h"
+#include "g2o/core/base_unary_edge.h"
+#include "g2o/types/sim3.h"
+#include "g2o/types/types_six_dof_expmap.h"
 
 namespace ORB_SLAM3 {
 class EdgeSE3ProjectXYZOnlyPose

--- a/include/SerializationUtils.h
+++ b/include/SerializationUtils.h
@@ -27,8 +27,9 @@
 #include <boost/serialization/vector.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/features2d/features2d.hpp>
-#include <sophus/se3.hpp>
 #include <vector>
+
+#include "sophus/se3.hpp"
 
 namespace ORB_SLAM3 {
 
@@ -83,7 +84,7 @@ void serializeMatrix(Archive& ar, cv::Mat& mat, const unsigned int version) {
         continuous = mat.isContinuous();
     }
 
-    ar& cols& rows& type& continuous;
+    ar & cols & rows & type & continuous;
 
     if (Archive::is_loading::value) mat.create(rows, cols, type);
 
@@ -121,7 +122,7 @@ void serializeVectorKeyPoints(Archive& ar, const std::vector<cv::KeyPoint>& vKP,
         NumEl = vKP.size();
     }
 
-    ar& NumEl;
+    ar & NumEl;
 
     std::vector<cv::KeyPoint> vKPaux = vKP;
     if (Archive::is_loading::value) vKPaux.reserve(NumEl);
@@ -133,13 +134,13 @@ void serializeVectorKeyPoints(Archive& ar, const std::vector<cv::KeyPoint>& vKP,
 
         if (Archive::is_saving::value) KPi = vKPaux[i];
 
-        ar& KPi.angle;
-        ar& KPi.response;
-        ar& KPi.size;
-        ar& KPi.pt.x;
-        ar& KPi.pt.y;
-        ar& KPi.class_id;
-        ar& KPi.octave;
+        ar & KPi.angle;
+        ar & KPi.response;
+        ar & KPi.size;
+        ar & KPi.pt.x;
+        ar & KPi.pt.y;
+        ar & KPi.class_id;
+        ar & KPi.octave;
 
         if (Archive::is_loading::value) vKPaux.push_back(KPi);
     }

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -30,7 +30,7 @@
 #include "Frame.h"
 #include "ImuTypes.h"
 #include "ORBVocabulary.h"
-#include "Thirdparty/Sophus/sophus/se3.hpp"
+#include "sophus/se3.hpp"
 
 namespace ORB_SLAM3 {
 

--- a/include/TwoViewReconstruction.h
+++ b/include/TwoViewReconstruction.h
@@ -24,7 +24,8 @@
 
 #include <Eigen/Core>
 #include <opencv2/opencv.hpp>
-#include <sophus/se3.hpp>
+
+#include "sophus/se3.hpp"
 
 namespace ORB_SLAM3 {
 

--- a/src/Atlas.cc
+++ b/src/Atlas.cc
@@ -21,9 +21,9 @@
 
 #include "Atlas.h"
 
-#include "GeometricCamera.h"
-#include "KannalaBrandt8.h"
-#include "Pinhole.h"
+#include "CameraModels/GeometricCamera.h"
+#include "CameraModels/KannalaBrandt8.h"
+#include "CameraModels/Pinhole.h"
 #include "Viewer.h"
 
 namespace ORB_SLAM3 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,16 +68,16 @@ target_link_libraries(${PROJECT_NAME}
     ${OpenCV_LIBS}
     ${EIGEN3_LIBS}
     ${Pangolin_LIBRARIES}
-    ${PROJECT_SOURCE_DIR}/Thirdparty/DBoW2/lib/libDBoW2.so
-    ${PROJECT_SOURCE_DIR}/Thirdparty/g2o/lib/libg2o.so
+    DBoW2
+    g2o
     -lboost_serialization
     -lcrypto
 )
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC ${PROJECT_SOURCE_DIR}/include
-    PUBLIC ${PROJECT_SOURCE_DIR}/include/CameraModels
-    PUBLIC ${PROJECT_SOURCE_DIR}
+    PUBLIC ${PROJECT_SOURCE_DIR}/Thirdparty/g2o
+    PUBLIC ${PROJECT_SOURCE_DIR}/Thirdparty/DBoW2
     PUBLIC ${PROJECT_SOURCE_DIR}/Thirdparty/Sophus
     PRIVATE ${EIGEN3_INCLUDE_DIR}
     PRIVATE ${Pangolin_INCLUDE_DIRS}

--- a/src/CameraModels/KannalaBrandt8.cc
+++ b/src/CameraModels/KannalaBrandt8.cc
@@ -19,7 +19,7 @@
  * ORB-SLAM3. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "KannalaBrandt8.h"
+#include "CameraModels/KannalaBrandt8.h"
 
 #include <boost/serialization/export.hpp>
 

--- a/src/CameraModels/Pinhole.cc
+++ b/src/CameraModels/Pinhole.cc
@@ -19,7 +19,7 @@
  * ORB-SLAM3. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Pinhole.h"
+#include "CameraModels/Pinhole.h"
 
 #include <boost/serialization/export.hpp>
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -21,14 +21,13 @@
 
 #include "Frame.h"
 
-#include <include/CameraModels/KannalaBrandt8.h>
-#include <include/CameraModels/Pinhole.h>
-
 #include <thread>
 
+#include "CameraModels/GeometricCamera.h"
+#include "CameraModels/KannalaBrandt8.h"
+#include "CameraModels/Pinhole.h"
 #include "Converter.h"
 #include "G2oTypes.h"
-#include "GeometricCamera.h"
 #include "KeyFrame.h"
 #include "MapPoint.h"
 #include "ORBextractor.h"

--- a/src/G2oTypes.cc
+++ b/src/G2oTypes.cc
@@ -21,8 +21,8 @@
 
 #include "G2oTypes.h"
 
+#include "CameraModels/GeometricCamera.h"
 #include "Frame.h"
-#include "GeometricCamera.h"
 #include "ImuTypes.h"
 #include "KeyFrame.h"
 

--- a/src/GeometricTools.cc
+++ b/src/GeometricTools.cc
@@ -21,7 +21,7 @@
 
 #include "GeometricTools.h"
 
-#include "GeometricCamera.h"
+#include "CameraModels/GeometricCamera.h"
 #include "KeyFrame.h"
 
 namespace ORB_SLAM3 {

--- a/src/KeyFrame.cc
+++ b/src/KeyFrame.cc
@@ -23,9 +23,9 @@
 
 #include <mutex>
 
+#include "CameraModels/GeometricCamera.h"
 #include "Converter.h"
 #include "Frame.h"
-#include "GeometricCamera.h"
 #include "ImuTypes.h"
 #include "KeyFrameDatabase.h"
 #include "Map.h"

--- a/src/KeyFrameDatabase.cc
+++ b/src/KeyFrameDatabase.cc
@@ -23,10 +23,10 @@
 
 #include <mutex>
 
+#include "DBoW2/BowVector.h"
 #include "Frame.h"
 #include "KeyFrame.h"
 #include "Map.h"
-#include "Thirdparty/DBoW2/DBoW2/BowVector.h"
 
 using namespace std;
 

--- a/src/LocalMapping/CreateNewMapPoints.cc
+++ b/src/LocalMapping/CreateNewMapPoints.cc
@@ -1,5 +1,5 @@
 #include "Atlas.h"
-#include "GeometricCamera.h"
+#include "CameraModels/GeometricCamera.h"
 #include "GeometricTools.h"
 #include "LocalMapping.h"
 #include "Map.h"

--- a/src/MLPnPsolver.cc
+++ b/src/MLPnPsolver.cc
@@ -53,8 +53,8 @@
 
 #include <Eigen/Sparse>
 
+#include "CameraModels/GeometricCamera.h"
 #include "Converter.h"
-#include "GeometricCamera.h"
 
 namespace ORB_SLAM3 {
 MLPnPsolver::MLPnPsolver(const Frame &F,

--- a/src/ORBmatcher.cc
+++ b/src/ORBmatcher.cc
@@ -25,8 +25,8 @@
 
 #include <opencv2/core/core.hpp>
 
-#include "GeometricCamera.h"
-#include "Thirdparty/DBoW2/DBoW2/FeatureVector.h"
+#include "CameraModels/GeometricCamera.h"
+#include "DBoW2/FeatureVector.h"
 
 using namespace std;
 

--- a/src/Optimizer.cc
+++ b/src/Optimizer.cc
@@ -29,14 +29,14 @@
 #include "G2oTypes.h"
 #include "OptimizableTypes.h"
 #include "System.h"
-#include "Thirdparty/g2o/g2o/core/block_solver.h"
-#include "Thirdparty/g2o/g2o/core/optimization_algorithm_gauss_newton.h"
-#include "Thirdparty/g2o/g2o/core/optimization_algorithm_levenberg.h"
-#include "Thirdparty/g2o/g2o/core/robust_kernel_impl.h"
-#include "Thirdparty/g2o/g2o/solvers/linear_solver_dense.h"
-#include "Thirdparty/g2o/g2o/solvers/linear_solver_eigen.h"
-#include "Thirdparty/g2o/g2o/types/types_seven_dof_expmap.h"
-#include "Thirdparty/g2o/g2o/types/types_six_dof_expmap.h"
+#include "g2o/core/block_solver.h"
+#include "g2o/core/optimization_algorithm_gauss_newton.h"
+#include "g2o/core/optimization_algorithm_levenberg.h"
+#include "g2o/core/robust_kernel_impl.h"
+#include "g2o/solvers/linear_solver_dense.h"
+#include "g2o/solvers/linear_solver_eigen.h"
+#include "g2o/types/types_seven_dof_expmap.h"
+#include "g2o/types/types_six_dof_expmap.h"
 
 namespace ORB_SLAM3 {
 bool sortByVal(const pair<MapPoint*, int>& a, const pair<MapPoint*, int>& b) {

--- a/src/Sim3Solver.cc
+++ b/src/Sim3Solver.cc
@@ -25,11 +25,10 @@
 #include <opencv2/core/core.hpp>
 #include <vector>
 
+#include "CameraModels/GeometricCamera.h"
 #include "Converter.h"
-#include "GeometricCamera.h"
 #include "KeyFrame.h"
 #include "MapPoint.h"
-#include "Thirdparty/DBoW2/DUtils/Random.h"
 
 namespace ORB_SLAM3 {
 

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -24,9 +24,9 @@
 #include <iostream>
 #include <mutex>
 
+#include "CameraModels/GeometricCamera.h"
 #include "FrameDrawer.h"
 #include "G2oTypes.h"
-#include "GeometricCamera.h"
 #include "GeometricTools.h"
 #include "MLPnPsolver.h"
 #include "ORBextractor.h"

--- a/src/TwoViewReconstruction.cc
+++ b/src/TwoViewReconstruction.cc
@@ -23,8 +23,8 @@
 
 #include <thread>
 
+#include "DUtils/Random.h"
 #include "GeometricTools.h"
-#include "Thirdparty/DBoW2/DUtils/Random.h"
 
 using namespace std;
 namespace ORB_SLAM3 {


### PR DESCRIPTION
基本的に
- インクルードディレクトリをincludeとThirdparty/*にしてルートディレクトリを除外した
- src/CMakeLists.txtでDBoW2とg2oのライブラリのパスを直接指定してたからライブラリ名に変更した